### PR TITLE
Macro: get values from HashMap only once

### DIFF
--- a/common_macro/src/main/scala/com/github/scalalab3/logs/convertFromMap.scala
+++ b/common_macro/src/main/scala/com/github/scalalab3/logs/convertFromMap.scala
@@ -4,16 +4,18 @@ import java.util.HashMap
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 
+
 trait FromMap[T] {
+  implicit class HashMapExt(x: HashMap[String, Any]) {
+    def safeGet(k: String) = Option(x.get(k))
+  }
+
   def fromMap(map: HashMap[String, Any]): Option[T]
 }
 
 object FromMap {
-  implicit def materializeMappable[T]: FromMap[T] = macro materializeMappableImpl[T]
 
-  implicit class HashMapExt(x: HashMap[_, _]) {
-    def safeGet[T](k: String) = Option(x.get(k))
-  }
+  implicit def materializeMappable[T]: FromMap[T] = macro materializeMappableImpl[T]
 
   def materializeMappableImpl[T: c.WeakTypeTag](c: whitebox.Context):
       c.Expr[FromMap[T]] = {
@@ -32,17 +34,6 @@ object FromMap {
       case m: MethodSymbol if m.isPrimaryConstructor => m
     }.get.paramLists.head
 
-    val assignValues = fields.map { field =>
-      val name = field.name.toTermName
-      val decoded = name.decodedName.toString
-
-      val ret = decoded match {
-        case "id" => q"Option(map.safeGet($decoded))"
-        case _ => q"map.safeGet($decoded)"
-      }
-      q"val $name = $ret"
-    }
-
     val names = fields.map { field =>
       val name = field.name.toTermName
       q"$name"
@@ -57,27 +48,14 @@ object FromMap {
         case "id" => q"Option(map.safeGet($decoded))"
         case _ => q"map.safeGet($decoded)"
       }
-      fq"$name <- $ret"
+      fq"$name <- $ret.map(_.asInstanceOf[$returnType])"
     }
 
-    val namesInst = fields.map { field =>
-      val name = field.name.toTermName
-      val returnType = tpe.decl(name).typeSignature
-      q"$name.asInstanceOf[$returnType]"
-    }
-
-    println(q"""
-      new FromMap[$tpe] {
-        def fromMap(map: java.util.HashMap[String, Any]): Option[$tpe] = {
-          for (..$forLoop) yield $companion(..$namesInst)
-        }
-      }
-    """)
     c.Expr[FromMap[T]] {
       q"""
       new FromMap[$tpe] {
         def fromMap(map: java.util.HashMap[String, Any]): Option[$tpe] = {
-          for (..$forLoop) yield $companion(..$namesInst)
+          for (..$forLoop) yield $companion(..$names)
         }
       }
     """


### PR DESCRIPTION
Fixed previous macro implementation.
Now it generate code like:

```scala
{
  final class $anon extends FromMap[com.github.scalalab3.logs.common.Log] {
    def <init>() = {
      super.<init>();
      ()
    };
    def fromMap(map: java.util.HashMap[String, Any]): Option[com.github.scalalab3.logs.common.Log] = {
      val id = Option(map.get("id"));
      val level = map.get("level");
      val env = map.get("env");
      val name = map.get("name");
      val timestamp = map.get("timestamp");
      val message = map.get("message");
      val cause = map.get("cause");
      val stackTrace = map.get("stackTrace");
      if (scala.collection.immutable.List(id, level, env, name, timestamp, message, cause, stackTrace).contains(null))
        None
      else
        Some(Log(id.asInstanceOf[=> Option[java.util.UUID]], level.asInstanceOf[=> Integer], env.asInstanceOf[=> String], name.asInstanceOf[=> String], timestamp.asInstanceOf[=> java.time.Instant], message.asInstanceOf[=> String], cause.asInstanceOf[=> String], stackTrace.asInstanceOf[=> String]))
    }
  };
  new $anon()
}
```