### PR TITLE
Structure: move json implicits to common

### DIFF
--- a/common/src/main/scala/com/github/scalalab3/logs/common/json/LogJsonImplicits.scala
+++ b/common/src/main/scala/com/github/scalalab3/logs/common/json/LogJsonImplicits.scala
@@ -1,4 +1,4 @@
-package com.github.scalalab3.logs.json
+package com.github.scalalab3.logs.common.json
 
 import com.github.scalalab3.logs.common.{Level, Log}
 import play.api.libs.json.{JsString, JsValue, Json, Writes}

--- a/src/main/scala/com/github/scalalab3/logs/http/AbstractHttpService.scala
+++ b/src/main/scala/com/github/scalalab3/logs/http/AbstractHttpService.scala
@@ -2,7 +2,7 @@ package com.github.scalalab3.logs.http
 
 import akka.actor.ActorRef
 import akka.util.Timeout
-import com.github.scalalab3.logs.json.LogJsonImplicits._
+import com.github.scalalab3.logs.common.json.LogJsonImplicits._
 import com.github.scalalab3.logs.services.{AbstractResponse, BadRequest, LogsResponse, PageLogsResponse}
 import spray.http.HttpHeaders.RawHeader
 import spray.http.{HttpEntity, HttpResponse, StatusCodes}

--- a/src/main/scala/com/github/scalalab3/logs/http/WsApi.scala
+++ b/src/main/scala/com/github/scalalab3/logs/http/WsApi.scala
@@ -12,7 +12,7 @@ import org.java_websocket.server.WebSocketServer
 import play.api.libs.json._
 
 class WsApi(val config: WebConfig) extends AbstractActor {
-  import com.github.scalalab3.logs.json.LogJsonImplicits._
+  import com.github.scalalab3.logs.common.json.LogJsonImplicits._
 
   log.info("WS Api start...")
 
@@ -21,7 +21,7 @@ class WsApi(val config: WebConfig) extends AbstractActor {
 
   val socketServer = new SocketServer(config.host, config.wsPort, log)
   socketServer.start()
-  
+
   def receive = {
     case change: Log => socketServer.send(Json.toJson(change).toString())
   }


### PR DESCRIPTION
I need json imlicits in tests module to create macro_tests, so let's move it in more general module than root